### PR TITLE
set文羅列とdelete文羅列を入力すると、deleteを適用したset文羅列にできる差分

### DIFF
--- a/exe/junoser
+++ b/exe/junoser
@@ -27,6 +27,10 @@ opts = OptionParser.new do |opts|
     command = :struct
   end
 
+  opts.on '--delete', 'Apply config delete sentence' do
+    command = :delete
+  end
+
   opts.on_tail '-h', '--help', 'Show this message' do
     puts opts
     exit
@@ -46,6 +50,8 @@ when :display_set
   puts Junoser::Cli.display_set($<)
 when :struct
   puts Junoser::Cli.struct($<)
+when :delete
+  puts Junoser::Cli.delete($<)
 else
   puts opts
   abort

--- a/exe/junoser
+++ b/exe/junoser
@@ -27,10 +27,6 @@ opts = OptionParser.new do |opts|
     command = :struct
   end
 
-  opts.on '--delete', 'Apply config delete sentence' do
-    command = :delete
-  end
-
   opts.on_tail '-h', '--help', 'Show this message' do
     puts opts
     exit
@@ -50,8 +46,6 @@ when :display_set
   puts Junoser::Cli.display_set($<)
 when :struct
   puts Junoser::Cli.struct($<)
-when :delete
-  puts Junoser::Cli.delete($<)
 else
   puts opts
   abort

--- a/exe/junoser-apply
+++ b/exe/junoser-apply
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'pathname'
+
+$: << File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+require 'junoser'
+
+
+command = :apply
+opts = OptionParser.new do |opts|
+  opts.banner = 'junoser-apply: apply commands to config. (delete)'
+  opts.define_head 'Usage: junoser-apply [path]'
+
+  opts.on_tail '-h', '--help', 'Show this message' do
+    puts opts
+    exit
+  end
+end
+opts.parse!
+case command
+  when :apply
+    puts Junoser::Cli.apply($<)
+  else
+    puts opts
+    abort
+end

--- a/exe/junoser-compare
+++ b/exe/junoser-compare
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'pathname'
+
+$: << File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+require 'junoser'
+
+
+command = :compare
+opts = OptionParser.new do |opts|
+  opts.banner = 'junoser-compare: output difference between two configs'
+  opts.define_head 'Usage: junoser-compare [path] [path]'
+
+  opts.on_tail '-h', '--help', 'Show this message' do
+    puts opts
+    exit
+  end
+end
+opts.parse!
+case command
+  when :compare
+    puts Junoser::Cli.compare($<)
+  else
+    puts opts
+    abort
+end

--- a/lib/junoser/cli.rb
+++ b/lib/junoser/cli.rb
@@ -25,6 +25,10 @@ module Junoser
         Junoser::Display::Structure.new(io_or_string).transform
       end
 
+      def delete(io_or_string)
+        Junoser::Display::Delete.new(io_or_string).apply
+      end
+
 
       private
 

--- a/lib/junoser/cli.rb
+++ b/lib/junoser/cli.rb
@@ -25,10 +25,13 @@ module Junoser
         Junoser::Display::Structure.new(io_or_string).transform
       end
 
-      def delete(io_or_string)
+      def apply(io_or_string)
         Junoser::Display::Delete.new(io_or_string).apply
       end
 
+      def compare(io_or_string)
+        Junoser::Display::Compare.new(io_or_string).diff
+      end
 
       private
 

--- a/lib/junoser/display.rb
+++ b/lib/junoser/display.rb
@@ -1,6 +1,7 @@
 require 'junoser/display/set'
 require 'junoser/display/structure'
 require 'junoser/display/delete'
+require 'junoser/display/compare'
 
 module Junoser
   module Display

--- a/lib/junoser/display.rb
+++ b/lib/junoser/display.rb
@@ -1,5 +1,6 @@
 require 'junoser/display/set'
 require 'junoser/display/structure'
+require 'junoser/display/delete'
 
 module Junoser
   module Display

--- a/lib/junoser/display/compare.rb
+++ b/lib/junoser/display/compare.rb
@@ -1,0 +1,175 @@
+require 'junoser/input'
+require 'junoser/display/config_store'
+require 'junoser/parser'
+require 'junoser/transformer'
+
+module Junoser
+  module Display
+    class Compare
+      def initialize(io_or_string)
+        @input = io_or_string
+      end
+      def diff
+        master,branch = Junoser::Input.new(@input).read2
+        master_struct = Junoser::Display::Structure.new(master).transform
+        branch_struct = Junoser::Display::Structure.new(branch).transform
+        generate_diff_set_and_delete(master_struct,branch_struct)
+      end
+
+      private
+
+      def generate_diff_set_and_delete(master,branch)
+        master_hash = struct_to_hash(master)
+        branch_hash = struct_to_hash(branch)
+        set_hash = hash_cmp(master_hash,branch_hash,"set")
+        delete_hash = hash_cmp(master_hash,branch_hash,"delete")
+        set_struct = hash_to_struct(set_hash)
+        delete_struct = hash_to_struct(delete_hash)
+        set_ = Junoser::Display::Set.new(set_struct).transform
+        delete_ = Junoser::Display::Set.new(delete_struct).transform
+        delete_.gsub!(/^set /, 'delete ')
+        delete_ << "\n" << set_
+      end
+
+
+      def hash_cmp(master,branch,delete_or_set,depth = 0)
+        if delete_or_set == "set" and depth == 0
+          tmp = master
+          master = branch
+          branch = tmp
+        end
+        answer = {}
+        master.each do |key,value|
+          if branch.key?(key)
+            if not including(value,branch[key])
+              answer.store(key,hash_cmp(value,branch[key],delete_or_set,depth + 1))
+            end
+          else
+            if delete_or_set == "delete"
+              answer.store(key,{})
+            elsif delete_or_set == "set"
+              answer.store(key,value)
+            end
+          end
+        end
+        answer
+      end
+
+      def including(hash,hash2)
+        # hash <= hash2
+        if hash.keys - hash2.keys == []
+          if hash == {}
+            return true
+          else
+            hash.each do |key,value|
+              if not including(value,hash2[key])
+                return false
+              end
+            end
+          end
+        else
+          return false
+        end
+        true
+      end
+
+      def struct_to_hash(struct)
+        struct.gsub!(/\n/, '')
+        hash = struct_to_first_hash(struct)
+        hash_value_to_hash(hash)
+      end
+
+      def hash_value_to_hash(hash)
+        hash.each do |key,value|
+          if value != {}
+            hash.store(key,struct_to_first_hash(value))
+            hash_value_to_hash(hash[key])
+          end
+        end
+      end
+
+      def struct_to_first_hash(struct)
+        hash = {}
+        key,value = "",""
+        state = 0
+        struct.strip!
+        struct.chars.each do |c|
+          case state
+            when 0 then # initial state
+              case c
+                when "{" then
+                  state += 1 # 1
+                when ";" then
+                  hash.store(key.strip,value.strip)
+                  key,value = "",""
+                else
+                  key << c
+              end
+            when 1 then
+              case c
+                when "{" then
+                  value << c
+                  state += 1 # 2
+                when "}" then
+                  hash.store(key.strip,value.strip)
+                  key,value = "",""
+                  state -= 1 # 0
+                else
+                  value << c
+              end
+            else
+              case c
+                when "{" then
+                  value << c
+                  state += 1
+                when "}" then
+                  value << c
+                  state -= 1
+                else
+                  value << c
+              end
+          end
+        end
+        hash
+      end
+
+      def apply_delete(set_hash,delete_line_hash)
+        key,hash = ret_first_key_and_value(delete_line_hash)
+        if hash == {}
+          set_hash.delete(key)
+          set_hash
+        else
+          apply_delete(set_hash[key],hash)
+        end
+        set_hash
+      end
+
+      def hash_to_struct(hash)
+        struct = ""
+        hash_to_struct_iter(hash){|str| struct << str}
+        struct
+      end
+
+      def hash_to_struct_iter(hash,&block)
+        hash.each_with_index do |(key,value),i|
+          yield key
+          if value != {}
+            yield "{\n"
+            hash_to_struct_iter(value,&block)
+          else
+            yield ";\n"
+          end
+          if i == hash.length - 1
+            yield "}\n"
+          end
+        end
+      end
+
+      def ret_first_key_and_value(hash)
+        hash.each do |key,hash|
+          return key,hash
+        end
+      end
+    end
+  end
+end

--- a/lib/junoser/display/delete.rb
+++ b/lib/junoser/display/delete.rb
@@ -20,9 +20,8 @@ module Junoser
           delete_line_hash = struct_to_hash(delete_line_struct)
           set_h = apply_delete(set_h,delete_line_hash)
         end
-        set_h
-#        set_struct = hash_to_struct(set_h)
-#        Junoser::Display::Set.new(set_struct).transform
+        set_struct = hash_to_struct(set_h)
+        Junoser::Display::Set.new(set_struct).transform
       end
 
       private
@@ -89,9 +88,26 @@ module Junoser
         set_hash
       end
 
-#      def hash_to_struct(hash)
-#
-#      end
+      def hash_to_struct(hash)
+        struct = ""
+        hash_to_struct_iter(hash){|str| struct << str}
+        struct
+      end
+
+      def hash_to_struct_iter(hash,&block)
+        hash.each_with_index do |(key,value),i|
+          yield key
+          if value != {}
+            yield "{\n"
+            hash_to_struct_iter(value,&block)
+          else
+            yield ";\n"
+          end
+          if i == hash.length - 1
+            yield "}\n"
+          end
+        end
+      end
 
       def ret_first_key_and_value(hash)
         hash.each do |key,hash|

--- a/lib/junoser/display/delete.rb
+++ b/lib/junoser/display/delete.rb
@@ -46,50 +46,50 @@ module Junoser
         end
       end
 
-    def struct_to_first_hash(struct)
-      hash = {}
-      ar = ["",""]
-      state = 0
-      struct.strip!
-      struct.chars.each do |c|
-        case state
-          when 0 then # initial state
-            case c
-              when "{" then
-                state += 1
-              when ";" then
-                hash.store(ar[0].strip,ar[1].strip)
-                ar = ["",""]
-              else
-                ar[0] << c
-            end
-          when 1 then
-            case c
-              when "{" then
-                ar[1] << c
-                state += 1
-              when "}" then
-                hash.store(ar[0].strip,ar[1].strip)
-                ar = ["",""]
-                state = 0
-              else
-                ar[1] << c
-            end
-          else
-            case c
-              when "{" then
-                ar[1] << c
-                state += 1
-              when "}" then
-                ar[1] << c
-                state -= 1
-              else
-                ar[1] << c
-            end
+      def struct_to_first_hash(struct)
+        hash = {}
+        key,value = "",""
+        state = 0
+        struct.strip!
+        struct.chars.each do |c|
+          case state
+            when 0 then # initial state
+              case c
+                when "{" then
+                  state += 1 # 1
+                when ";" then
+                  hash.store(key.strip,value.strip)
+                  key,value = "",""
+                else
+                  key << c
+              end
+            when 1 then
+              case c
+                when "{" then
+                  value << c
+                  state += 1 # 2
+                when "}" then
+                  hash.store(key.strip,value.strip)
+                  key,value = "",""
+                  state -= 1 # 0
+                else
+                  value << c
+              end
+            else
+              case c
+                when "{" then
+                  value << c
+                  state += 1
+                when "}" then
+                  value << c
+                  state -= 1
+                else
+                  value << c
+              end
+          end
         end
+        hash
       end
-      hash
-    end
 
       def apply_delete(set_hash,delete_line_hash)
         key,hash = ret_first_key_and_value(delete_line_hash)

--- a/lib/junoser/display/delete.rb
+++ b/lib/junoser/display/delete.rb
@@ -1,0 +1,103 @@
+require 'junoser/input'
+require 'junoser/display/config_store'
+require 'junoser/parser'
+require 'junoser/transformer'
+
+module Junoser
+  module Display
+    class Delete
+      def initialize(io_or_string)
+        @input = io_or_string
+      end
+      def apply
+        sd = Junoser::Input.new(@input).read.split("\n")
+        d = sd.grep(/^delete /).map {|l| l.sub(/^delete /, 'set ')}
+        s = sd.grep(/^set /)
+        set_struct = Junoser::Display::Structure.new(s.join("\n")).transform
+        set_h = struct_to_hash(set_struct)
+        d.each do |delete_line|
+          delete_line_struct = Junoser::Display::Structure.new(delete_line).transform
+          delete_line_hash = struct_to_hash(delete_line_struct)
+          set_h = apply_delete(set_h,delete_line_hash)
+        end
+        set_h
+#        set_struct = hash_to_struct(set_h)
+#        Junoser::Display::Set.new(set_struct).transform
+      end
+
+      private
+
+      def struct_to_hash(struct)
+        struct.gsub!(/\n/, '')
+        hash = struct_to_first_hash(struct)
+        hash_value_to_hash(hash)
+      end
+
+      def hash_value_to_hash(hash)
+        hash.each do |key,value|
+          if value != {}
+            hash.store(key,struct_to_first_hash(value))
+            hash_value_to_hash(hash[key])
+          end
+        end
+      end
+
+      def struct_to_first_hash(struct)
+        hash = {}
+        ar = ["",""]
+        num = 0
+        flag = 0
+        struct << " "
+        struct.chars.each do |c|
+          if num != 0
+            ar[1] << c
+          end
+          if c == "{"
+            num = num + 1
+            flag = 1
+            next
+          end
+          if c == "}"
+            num = num - 1
+            next
+          end
+          if num == 0
+            if c == ";"
+              hash.store(ar[0].strip,{})
+              ar = ["",""]
+              next
+            end
+            if flag == 1
+              hash.store(ar[0].strip,ar[1].chop.strip)
+              ar = ["",""]
+              flag = 0
+            end
+            ar[0] << c
+          end
+        end
+        hash
+      end
+
+      def apply_delete(set_hash,delete_line_hash)
+        key,hash = ret_first_key_and_value(delete_line_hash)
+        if hash == {}
+          set_hash.delete(key)
+          set_hash
+        else
+          apply_delete(set_hash[key],hash)
+        end
+        set_hash
+      end
+
+#      def hash_to_struct(hash)
+#
+#      end
+
+      def ret_first_key_and_value(hash)
+        hash.each do |key,hash|
+          return key,hash
+        end
+      end
+    end
+  end
+end

--- a/lib/junoser/input.rb
+++ b/lib/junoser/input.rb
@@ -15,6 +15,30 @@ module Junoser
       content = unify_carriage_return(content)
     end
 
+    def read2
+      content1 = if @io_or_string.respond_to?(:read)
+                  @io_or_string.file.read
+                else
+                  @io_or_string.to_s
+                end
+
+      content1 = remove_blank_and_comment_line(content1)
+      content1 = unify_carriage_return(content1)
+
+      @io_or_string.skip
+
+      content2 = if @io_or_string.respond_to?(:read)
+                   @io_or_string.file.read
+                 else
+                   @io_or_string.to_s
+                 end
+
+      content2 = remove_blank_and_comment_line(content2)
+      content2 = unify_carriage_return(content2)
+
+      return content1,content2
+    end
+
 
     private
 


### PR DESCRIPTION
大変僭越ながらJunoserの機能を実装したので、ご査収いただければ幸いです。
# 使い方
`junoser --delete CONFIG_FILE`
```
(01:06:45)20202461n: junoser$cat config 
set interfaces em0 unit 0 family inet address 1.1.1.1/32
set interfaces em0 unit 1 family inet mtu 1000
set interfaces em0 unit 1 family inet6
set interfaces em1 unit 0
set interfaces em2
delete interfaces em0 unit 0 family inet address 1.1.1.1/32
delete interfaces em0 unit 1
```
```
(01:06:48)20202461n: junoser$ruby exe/junoser --delete config 
set interfaces em0 unit 0 family inet
set interfaces em1 unit 0
set interfaces em2
```

# 概要
Delete文は既存のConfigによって適用のされ方が異なるという性質があります。
これは、手順書の自動作成においてこれを判断をするために人間の手が介入させなければならないというデメリットを生じさせてしまうものです。

例：
```
set interfaces em0 unit 0 family inet address 1.1.1.1/32
set interfaces em0 unit 1 family inet address 1.1.1.2/32
delete interfaces em0 unit 0 family inet address 1.1.1.1/32
↓
set interfaces em0 unit 0 family inet
set interfaces em0 unit 1 family inet address 1.1.1.2/32
```
```
set interfaces em0 unit 0 family inet address 1.1.1.1/32
set interfaces em0 unit 0 family inet address 1.1.1.2/32
delete interfaces em0 unit 0 family inet address 1.1.1.1/32
↓
set interfaces em0 unit 0 family inet address 1.1.1.2/32
```
Junoserは「機器にログインせずに作業が出来るようにする」という目的を元に作られていると認識しています。この機能は、この目的に合致するのではないかと考えています。

もしこの差分がマージされた場合、以下のようなメリットが考えられます。
* Junosに対する手順書作成スクリプトを書く際を考えます。これを実行すれば適用後のConfigが得られるため、Delete文が意図するDeleteを行っているかを、人間あるいはプログラム（こちらに対するメリットのほうが大きい）が確かめる術が出来ます。したがって、Delete文を含む作業時であっても、手順書作成のフルスクリプト化が可能になります。

# 実装

大まかなフローは以下になります。
```
入力
↓
set文とdelete文を分離
↓
set文をstructureに変換。
↓
さらにこれをhashに変換。(新実装部分)
↓
delete文を一行ずつhashにし、set文のhashと比較して、削除する。(新実装部分)
↓
最終的なset文のhashをstructureに変換 (新実装部分)
↓
structureをset形式に変換
↓
出力
```

## 関数
### apply
引数: io_or_string
戻り値: delete文適用後のset文羅列

set文とdelete文を分解し、いくつかの関数を呼び出し、処理する、メインのフローです。
### struct_to_hash
引数: struct
戻り値: hash

ConfigのStructureをHashに変換します。
後々Delete文を適用しやすくするためのものです。
内部では、struct_to_first_hashとhash_value_to_hashを用いています。
例
```
interface em0{
        unit 0{
                family inet;
        }
}
```
↓
```
{"interface em0" => {"unit 0" => {"family inet"=> {} }}}
```
### hash_value_to_hash
引数: hash
戻り値: hash

入力されたHashのValueたちをさらにstruct_to_first_hashでHash化していく再帰関数です。
### struct_to_first_hash
引数: struct
戻り値: hash

一番外側にある構造だけをHashにし、内側はすべて文字列として扱ってしまうものです。
例
```
interface em0{        unit 0{                family inet;        }}
```
↓
```
{"interface em0" => "unit0{                family inet;        }"}
```
### apply_delete
引数: set文のhash , delete文のhash
戻り値: 適用後のset文のhash

delete文は一行ずつ適用されるため、ret_first_key_and_value関数を用いて、hashの一番最初のKeyとValueを取得してくるものです。これによって、Set文のKeyと比較し、正しく削除します。
### hash_to_struct
引数: hash
戻り値: struct

最後にhashをStructに直すためのものです。
hash_to_struct_iterでジェネレートされるStringを追加していくだけのものです。

例
```
{"interface em0" => {"unit 0" => {"family inet"=> {} }}}
```
↓
```
interface em0{
unit 0{
family inet;
}
}
```

### hash_to_struct_iter
引数: hash
戻り値: string(structの部分)

Hashを少しずつStringになおしていき、最終的にStructureにします。
これを実現するためのジェネレータとなる再帰関数です。
### ret_first_key_and_value
引数: hash
戻り値: key,value

hashの一番最初のKeyとValueを取得します。Delete文は一文ずつ用いるので、最初だけで全てを取得したことになります。
