### PR TITLE
Add instructions on how to update parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ set protocols bgp group ebgp-peers neighbor 192.0.2.2
 
 Use ```junoser -s``` to translate into structured form.
 
+## Updating parser for new directives
+
+From [Juniper
+website](https://support.juniper.net/support/downloads/), you can
+download the XSD schema for the version of JunOS you want to target:
+
+ - Junos XML API
+ - Select your version
+ - Application Tools
+ - XML Schema for Configurator Data
+
+Put it in `tmp/`, update `xsd_path` in `Rakefile` and run:
+
+```zsh
+$ bundle exec rake build:config build:rule
+```
+
+Alternatively, you may look in `example/` for some prebuilt rules
+file. If you want to use them, copy one to `tmp/rules.rb` and run:
+
+```zsh
+$ bundle exec rake build:rule
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ download the XSD schema for the version of JunOS you want to target:
  - Application Tools
  - XML Schema for Configurator Data
 
+Alternatively, you can retrieve the schema with Netconf:
+
+```zsh
+$ ssh -Csp 830 JUNOS netconf < example/get-schema.xml | sed -n '/^<xsd:schema/,/^<\/xsd:schema/p' > junos-XXX.xsd
+```
+
 Put it in `tmp/`, update `xsd_path` in `Rakefile` and run:
 
 ```zsh

--- a/example/get-schema.xml
+++ b/example/get-schema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+  </capabilities>
+</hello>
+]]>]]>
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
+  <get-xnm-information>
+    <type>xml-schema</type>
+    <namespace>junos-configuration</namespace>
+  </get-xnm-information>
+</rpc>
+]]>]]>
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="2">
+  <close-session/>
+</rpc>


### PR DESCRIPTION
Also include the schema for JunOS 18.1R3-S9. It seems the schema is
not equipment specific as we only specify a version on Juniper
website.

Fix #16