### PR TITLE
Remove newline from documentation strings

### DIFF
--- a/lib/junoser/xsd/element.rb
+++ b/lib/junoser/xsd/element.rb
@@ -97,6 +97,7 @@ module Junoser
 
       def documentation
         @documentation ||= xml.xpath('./xsd:annotation/xsd:documentation').text
+        @documentation.delete!("\n")
         @documentation.empty? ? nil : @documentation
       end
     end


### PR DESCRIPTION
Otherwise, Ruby will choke on the generated parser.rb.